### PR TITLE
Docker-compose version of dnscrypt-server

### DIFF
--- a/stack-deployment/local-dev-test/dnscrypt-server/docker-compose.yml
+++ b/stack-deployment/local-dev-test/dnscrypt-server/docker-compose.yml
@@ -5,10 +5,6 @@ services:
     image: jedisct1/dnscrypt-server
     container_name: dnscrypt-server
     restart: unless-stopped
-    ulimits:
-      nofile:
-        soft: 90000
-        hard: 90000
     ports:
       - 4443:443/udp
       - 4443:443/tcp

--- a/stack-deployment/local-dev-test/dnscrypt-server/docker-compose.yml
+++ b/stack-deployment/local-dev-test/dnscrypt-server/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3'
+
+services:
+  dnscrypt-server:
+    image: jedisct1/dnscrypt-server
+    container_name: dnscrypt-server
+    restart: unless-stopped
+    ulimits:
+      nofile:
+        soft: 90000
+        hard: 90000
+    ports:
+      - 4443:443/udp
+      - 4443:443/tcp
+    networks:
+      piholed_static-network:
+        ipv4_address: 172.20.128.3
+    environment:
+      - TZ=Europe/Copenhagen
+    command: init -N hush.dns -E 172.20.128.3:4443
+
+networks:
+  piholed_static-network:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.20.128.0/24

--- a/stack-deployment/local-dev-test/dnscrypt-server/docker-compose.yml
+++ b/stack-deployment/local-dev-test/dnscrypt-server/docker-compose.yml
@@ -13,15 +13,13 @@ services:
       - 4443:443/udp
       - 4443:443/tcp
     networks:
-      piholed_static-network:
+      static-network:
         ipv4_address: 172.20.128.3
     environment:
       - TZ=Europe/Copenhagen
     command: init -N hush.dns -E 172.20.128.3:4443
 
 networks:
-  piholed_static-network:
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.20.128.0/24
+  static-network:
+    external:
+      name: piholed_static-network

--- a/stack-deployment/local-dev-test/dnscrypt-server/setup.sh
+++ b/stack-deployment/local-dev-test/dnscrypt-server/setup.sh
@@ -3,11 +3,7 @@
 cd "$(dirname "$(readlink -f "$0" || realpath "$0")")"
 
 # Initialize the dnscrypt-server. Pre-requisite for running the full svc. afterwards
-docker run --ulimit nofile=90000:90000 --name=dnscrypt-server -p 4443:443/udp -p 4443:443/tcp --network=piholed_static-network \
---ip 172.20.128.3 jedisct1/dnscrypt-server init -N hush.dns -E 172.20.128.3:4443
+docker-compose up -d
 
-# Start the dnscrypt-server
-docker start dnscrypt-server
-
-# Update the restart policy of the container
-docker update --restart=unless-stopped dnscrypt-server
+# Output the log
+docker-compose logs


### PR DESCRIPTION
Can't claim that I have completely understood your setup, but I just saw your docker commands and thought hey they would fit perfect in a docker-compose.
So I haven't checked the complete setup, but this one runs and spits out something that looks similar to what your setup.sh did. And it seems you end up with the same container running.
Hope you can use the input...
NOTE! I had some trouble with the network "piholed_static-network" so it is defined in the docker-compose file, and might conflict with already created networks.