### PR TITLE
Update to different dnscrypt-proxy container image

### DIFF
--- a/unit-deployment/dnscrypt-proxy/provider-cloudflare/docker-compose.yml
+++ b/unit-deployment/dnscrypt-proxy/provider-cloudflare/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     environment:
       DNSCRYPT_LISTEN_PORT: "5353"
       DNSCRYPT_SERVER_NAMES: "['cloudflare']"
-    image: djaydev/dnscrypt-proxy@sha256:66894f8c539917f6dc1a919a239d287e53ba88a832eb171e0210564ceb867171
+    image: klutchell/dnscrypt-proxy:2.1.2
     network_mode: "host"
     restart: unless-stopped

--- a/unit-deployment/dnscrypt-proxy/provider-own-server/docker-compose.yml
+++ b/unit-deployment/dnscrypt-proxy/provider-own-server/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       timeout: 20s
       retries: 3
       start_period: 5s
-    image: djaydev/dnscrypt-proxy@sha256:66894f8c539917f6dc1a919a239d287e53ba88a832eb171e0210564ceb867171
+    image: klutchell/dnscrypt-proxy:2.1.2
     network_mode: "host"
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
djaydev/dnscrypt-proxy seems to have gone the way of the dodo...

This new one is compiled from Golang source code and build multi-stage "FROM scratch".

Check it out: https://github.com/klutchell/dnscrypt-proxy-docker/blob/main/Dockerfile