### PR TITLE
Changed dnscrypt-server to docker-compose

### DIFF
--- a/unit-deployment/dnscrypt-server/docker-compose.yml
+++ b/unit-deployment/dnscrypt-server/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+
+services:
+  dnscrypt-server:
+    container_name: dnscrypt-server
+    ports:
+      - 5443:5443/udp
+      - 5443:5443/tcp
+    volumes:
+      - /LOCAL_CUSTOM_DNSCRYPT_SERVER_CONF_DIR/unbound-conf:/opt/unbound/etc/unbound/zones
+      - /LOCAL_CUSTOM_DNSCRYPT_SERVER_CONF_DIR/keys:/opt/encrypted-dns/etc/keys
+    image: nyvanga/dnscrypt-server:2022-10-11
+    restart: unless-stopped
+    command: ["start"]

--- a/unit-deployment/dnscrypt-server/setup.sh
+++ b/unit-deployment/dnscrypt-server/setup.sh
@@ -3,8 +3,5 @@
 cd "$(dirname "$(readlink -f "$0" || realpath "$0")")"
 
 # Initialize the dnscrypt-server. Pre-requisite for running the full svc. afterwards
-docker run --name=dnscrypt-server -p 443:443/udp -p 443:443/tcp \
---restart=unless-stopped \
--v /LOCAL_CUSTOM_DNSCRYPT_SERVER_CONF_DIR/unbound-conf:/opt/unbound/etc/unbound/zones \
--v /LOCAL_CUSTOM_DNSCRYPT_SERVER_CONF_DIR/keys:/opt/encrypted-dns/etc/keys \
-jedisct1/dnscrypt-server init -N NAME_TO_GIVE_YOUR_DNSCRYPT_SERVER -E WAN_IP_IN_FRONT_OF_THE_dnscrypt-server:443
+# REMEMBER! to change the volume mounts in the docker-compose.yml
+docker compose run dnscrypt-server init -N NAME_TO_GIVE_YOUR_DNSCRYPT_SERVER -E WAN_IP_IN_FRONT_OF_THE_dnscrypt-server:443


### PR DESCRIPTION
- Switched to multi-arch image of dnscrypt-server

It also turned out that the multi-arch image I found wasn't really maintained, and hadn't been building for 2 years.
https://github.com/expoli/dnscrypt-server-docker-image-builder/actions

So I setup my own on a fork of the above:
https://github.com/nyvanga/dnscrypt-server-docker-image-builder
But the build runs for more than an hour, so I am going to burn through my free plan in no time. So I won't build it regularly.